### PR TITLE
Improve SEO metadata

### DIFF
--- a/src/app/(withNav)/blog/[slug]/page.tsx
+++ b/src/app/(withNav)/blog/[slug]/page.tsx
@@ -20,6 +20,7 @@ export async function generateMetadata({
   return {
     title,
     description,
+    keywords: ["Suhas Kashyap", title],
     openGraph: {
       title: `${title} | Suhas Kashyap`,
       description,
@@ -32,6 +33,9 @@ export async function generateMetadata({
           url: heroImage,
         },
       ],
+    },
+    alternates: {
+      canonical: `https://kashyapsuhas.com/blog/${post.slug}`,
     },
   };
 }

--- a/src/app/(withNav)/blog/page.tsx
+++ b/src/app/(withNav)/blog/page.tsx
@@ -5,6 +5,10 @@ import { getBlogPosts } from "@/db/blog";
 export const metadata = {
   title: "Kashyap's Blog | Suhas Kashyap",
   description: "Kashyap's Blog.",
+  alternates: {
+    canonical: "https://kashyapsuhas.com/blog",
+  },
+  keywords: ["Suhas Kashyap", "blog"],
 };
 
 export default function Blog() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,20 @@ import { Eczar } from "next/font/google";
 const eczar = Eczar({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://kashyapsuhas.com"),
   title: "Suhas Kashyap",
   description: "Suhas Kashyap's personal website",
+  keywords: [
+    "Suhas",
+    "Kashyap",
+    "Suhas Kashyap",
+    "blog",
+    "photos",
+    "tools",
+  ],
+  alternates: {
+    canonical: "https://kashyapsuhas.com/",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+import { getBlogPosts } from "@/db/blog";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getBlogPosts();
+
+  return [
+    {
+      url: "https://kashyapsuhas.com",
+      lastModified: new Date().toISOString(),
+    },
+    {
+      url: "https://kashyapsuhas.com/blog",
+      lastModified: new Date().toISOString(),
+    },
+    ...posts.map((post) => ({
+      url: `https://kashyapsuhas.com/blog/${post.slug}`,
+      lastModified: post.metadata.publishedDateTime,
+    })),
+  ];
+}


### PR DESCRIPTION
## Summary
- set canonical and keywords in main layout
- add metadata to blog listing and posts
- generate a dynamic sitemap

## Testing
- `npm run lint` *(fails: Next.js ESLint plugin wants interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68408e0c4e0c8324a12abeb0000c1a0c