### PR TITLE
Correct wrapper class spacing

### DIFF
--- a/src/app/(withNav)/blog/page.tsx
+++ b/src/app/(withNav)/blog/page.tsx
@@ -17,7 +17,7 @@ export default function Blog() {
   });
 
   return (
-    <Wrapper className="md:mb-20w-full mb-12">
+    <Wrapper className="md:mb-20 w-full mb-12">
       <ul className="flex flex-col">
         {blogPosts.map((post) => (
           <Link key={post.slug} className="my-4" href={`/blog/${post.slug}`}>

--- a/src/app/(withNav)/tools/page.tsx
+++ b/src/app/(withNav)/tools/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function Tools() {
   return (
-    <Wrapper className="md:mb-20w-full mb-12">
+    <Wrapper className="md:mb-20 w-full mb-12">
       <ul className="flex flex-col">
 
         <li className="flex flex-col md:justify-between">

--- a/src/app/(withNav)/tools/text-diff/page.tsx
+++ b/src/app/(withNav)/tools/text-diff/page.tsx
@@ -61,7 +61,7 @@ export default function TextDiffPage() {
   const lines = diffLinesInline(textA, textB);
 
   return (
-    <Wrapper maxWidth='NARROW' className="md:mb-20w-full mb-12">
+    <Wrapper maxWidth='NARROW' className="md:mb-20 w-full mb-12">
       <h1 className="text-5xl font-medium md:text-8xl">Text Diff Tool</h1>
       <div className="flex flex-col md:flex-row gap-4">
         <label className="block w-full md:w-1/2">


### PR DESCRIPTION
## Summary
- fix class name spacing for md:mb-20 in wrapper usages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408e6834188324bdc3707123897068