### PR TITLE
Fix search snippet text

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,12 @@
     animation: marquee 10s linear infinite;
   }
 
+  /* Show the Japanese portion of the marquee via CSS so it isn't
+     included in the page's HTML text. */
+  .jp-marquee::before {
+    content: "\30B9\30CF\30B9 \30AB\30B7\30E3\30D7 ";
+  }
+
   .macos-shadow {
     box-shadow:
       0px 10px 30px rgba(0, 0, 0, 0.2),

--- a/src/components/TouchMarquee.tsx
+++ b/src/components/TouchMarquee.tsx
@@ -5,13 +5,15 @@ import { VT323, Silkscreen, Dela_Gothic_One } from "next/font/google";
 import { useEffect, useState } from "react";
 
 const marqueeFont = Dela_Gothic_One({ weight: "400", subsets: ["latin"] });
-const marqueeText = "スハス カシャプ Suhas Kashyap";
+// Show the Japanese transliteration visually using CSS so it isn't
+// included in the document text that search engines index.
+const marqueeText = "Suhas Kashyap";
 
 const MarqueeText = () => {
   return Array(10)
     .fill(marqueeText)
     .map((text: string, i: number) => (
-      <span key={i} className="mr-10">
+      <span key={i} className="mr-10 jp-marquee">
         {text}
       </span>
     ));


### PR DESCRIPTION
## Summary
- keep Japanese text in the marquee but render via CSS so it's not indexed
- add `.jp-marquee` utility class in `globals.css`

## Testing
- `npx next lint` *(fails: no-sync-scripts, react/display-name)*

------
https://chatgpt.com/codex/tasks/task_e_6840923e85188324b9d2ba9418727a61