### PR TITLE
fix reviews dialog overflow on mobile

### DIFF
--- a/src/app/(withNav)/reviews/Reviews.tsx
+++ b/src/app/(withNav)/reviews/Reviews.tsx
@@ -343,7 +343,7 @@ function Reviews({ reviews: initialReviews }: Props) {
                   <Dialog.Title className="text-2xl font-bold">
                     {review.name}
                   </Dialog.Title>
-                  <Dialog.Description className="flex items-center gap-6">
+                  <Dialog.Description className="flex flex-wrap items-center gap-3">
                     <span
                       className={cn(
                         "inline-flex rounded px-2 py-2 text-xs font-semibold leading-5",
@@ -403,6 +403,7 @@ function Reviews({ reviews: initialReviews }: Props) {
                       href={review.link}
                       target="_blank"
                       rel="noopener noreferrer"
+                      className="break-all"
                     >
                       See More: {review.link}
                     </a>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -54,7 +54,7 @@ function Content({
           "data-[state=open]:motion-opacity-in-0",
           "data-[state=open]:motion-translate-y-in-50",
           "data-[state=open]:motion-blur-in-md",
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded border bg-background p-6 shadow-lg motion-duration-200 sm:max-w-lg",
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[85dvh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded border bg-background p-6 shadow-lg motion-duration-200 sm:max-w-lg",
           className,
         )}
         {...props}


### PR DESCRIPTION
- wrap description flex items and reduce gap so category/date/recommend don't overflow
- add break-all to link url so long urls don't bleed out of dialog

https://claude.ai/code/session_01LVcHdQPHUSjqZV4NmdWu2k