### PR TITLE
Fix mobile tools layout and TinaCMS feature branch builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' TINA_PUBLIC_IS_LOCAL=true tinacms dev -c \"next dev --turbopack\"",
-    "build": "tinacms build && next build",
+    "build": "GITHUB_BRANCH=main tinacms build && next build",
     "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/(withNav)/tools/page.tsx
+++ b/src/app/(withNav)/tools/page.tsx
@@ -43,11 +43,11 @@ export default function Tools() {
       <ul className="flex flex-col gap-2 md:gap-6">
         {tools.map((tool) => (
           <Link key={tool.href} href={tool.href} className="group">
-            <li className="flex flex-row-reverse items-baseline gap-2 md:flex-row md:items-end md:justify-between">
+            <li className="flex flex-col md:flex-row md:items-end md:justify-between">
               <span className="flex-grow text-body-lg font-medium md:text-heading-sm">
                 {tool.name}
               </span>
-              <span className="min-w-20 text-base text-secondary group-hover:font-medium group-hover:text-accent md:min-w-fit md:text-lg">
+              <span className="text-sm text-secondary group-hover:font-medium group-hover:text-accent md:min-w-fit md:text-lg">
                 {tool.description}
               </span>
             </li>


### PR DESCRIPTION
## Summary

- Fix mobile tools page layout: replace `flex-row-reverse` with `flex-col` so tool name appears first and description below on small screens. Desktop layout unchanged.
- Fix TinaCMS build auth on feature branches: pin `GITHUB_BRANCH=main` in the build script so Vercel preview deploys don't fail with 403 from TinaCMS cloud.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxMzTRKoMpVtZWrF9xDTGD)_